### PR TITLE
Add animated chalk e to scroll

### DIFF
--- a/index.html
+++ b/index.html
@@ -14,6 +14,34 @@
       overflow-x: hidden;
     }
 
+    /* chalk-style "e" section */
+    #chalk-e {
+      background-color: #000;
+      display: flex;
+      justify-content: center;
+      align-items: center;
+      height: 100vh;
+    }
+
+    #chalk-e svg {
+      width: 200px;
+      height: auto;
+    }
+
+    #chalk-e path {
+      fill: none;
+      stroke: white;
+      stroke-width: 2;
+      stroke-dasharray: 500;
+      stroke-dashoffset: 500;
+      animation: draw 3s ease-out forwards;
+      filter: drop-shadow(0 0 1px white) blur(0.5px);
+    }
+
+    @keyframes draw {
+      to { stroke-dashoffset: 0; }
+    }
+
     #scroll-content {
       max-width: 800px;
       margin: 0 auto;
@@ -89,6 +117,13 @@
 <body class="starfield-theme">
   <!-- Starfield background -->
   <canvas id="starfield"></canvas>
+
+  <!-- Animated chalk letter "e" -->
+  <div id="chalk-e">
+    <svg viewBox="0 0 200 200">
+      <path d="M 60 100 C 60 80, 100 80, 100 100 C 100 120, 60 120, 60 100" />
+    </svg>
+  </div>
 
   <!-- Scroll content, initially hidden -->
   <div id="scroll-content">


### PR DESCRIPTION
## Summary
- style and animate chalk-like letter "e"
- embed the inline SVG before the scroll content

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_683a08432dd0832fa10f7aa8cbf33a5a