### PR TITLE
Refine enso timing and consolidate chalk link

### DIFF
--- a/conversation.js
+++ b/conversation.js
@@ -43,7 +43,7 @@ document.addEventListener('DOMContentLoaded', () => {
   }
 
   function attachShowLink() {
-    const link = document.getElementById('chalk-link');
+    const link = document.getElementById('toggle-link');
     if (link) {
       link.addEventListener('click', evt => {
         evt.preventDefault();

--- a/enso.html
+++ b/enso.html
@@ -6,7 +6,7 @@
   <title>Enso Word Embedding</title>
   <style>
     :root {
-      --enso-period: 10s;
+      --enso-period: 30s;
     }
     body {
       margin: 0;

--- a/index.html
+++ b/index.html
@@ -208,7 +208,6 @@
 
     <p><a href="https://emptiness.learndoteach.org/sol">if you wish to speak, the mirror is listening.</a></p>
     <p>learn • do • teach<br /><a href="https://learndoteach.org">learndoteach.org</a></p>
-    <p><a href="#" id="chalk-link">see how the chalk was placed</a></p>
 </div>
   <div id="scroll-footer">
     <p>this scroll was written in silence.<br />


### PR DESCRIPTION
## Summary
- remove the extra 'see how the chalk was placed' link on the scroll
- slow the rainbow enso rotation for calmness
- update conversation script to trigger from footer link

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_683c9030d734832f94e9fd89a429a11e