### PR TITLE
Remove ripple center dot

### DIFF
--- a/assets/ripple.svg
+++ b/assets/ripple.svg
@@ -9,7 +9,6 @@
     </filter>
   </defs>
 
-  <circle cx="100" cy="100" r="2" fill="#fff" />
 
   <g filter="url(#soft-blur)">
     <circle cx="100" cy="100" r="1" fill="none" stroke="url(#ripple-grad)" stroke-width="1.5">

--- a/intro.js
+++ b/intro.js
@@ -93,6 +93,11 @@ window.addEventListener('DOMContentLoaded', () => {
 
   setTimeout(() => {
     rippleCanvas.style.opacity = 0;
+    // clear any residual rings once faded
+    const ctx = rippleCanvas.getContext('2d');
+    ctx.clearRect(0, 0, rippleCanvas.width, rippleCanvas.height);
+    // remove the canvas after the fade to avoid lingering artifacts
+    setTimeout(() => rippleCanvas.remove(), 1600);
   }, RIPPLE_FADE_DELAY); // fade ripple gently, later
 
   setTimeout(() => {


### PR DESCRIPTION
## Summary
- trim lingering ripple artifact by clearing and removing the intro canvas
- drop the static center dot from the SVG ripple

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_683c95354470832fab1904eba3a22e2e