### PR TITLE
Improve intro ripple removal and mobile starfield

### DIFF
--- a/index.html
+++ b/index.html
@@ -108,6 +108,8 @@
       height: 100vh;
       z-index: 0;
       pointer-events: none;
+      will-change: transform;
+      transform: translate3d(0, 0, 0);
       opacity: 0;
       transition: opacity 2s ease;
     }

--- a/intro.js
+++ b/intro.js
@@ -82,6 +82,8 @@ window.addEventListener('DOMContentLoaded', () => {
   rippleCanvas.style.position = 'absolute';
   rippleCanvas.style.top = 0;
   rippleCanvas.style.left = 0;
+  rippleCanvas.style.zIndex = 99;
+  rippleCanvas.style.pointerEvents = 'none';
   rippleCanvas.style.opacity = 0;
   rippleCanvas.style.transition = 'opacity 1.5s ease-in-out';
   intro.appendChild(rippleCanvas);
@@ -92,12 +94,15 @@ window.addEventListener('DOMContentLoaded', () => {
   }, RIPPLE_START_DELAY); // slight delay after load
 
   setTimeout(() => {
-    rippleCanvas.style.opacity = 0;
-    // clear any residual rings once faded
+    // clear any residual rings before fading out
     const ctx = rippleCanvas.getContext('2d');
     ctx.clearRect(0, 0, rippleCanvas.width, rippleCanvas.height);
-    // remove the canvas after the fade to avoid lingering artifacts
-    setTimeout(() => rippleCanvas.remove(), 1600);
+    const remove = () => {
+      rippleCanvas.removeEventListener('transitionend', remove);
+      rippleCanvas.remove();
+    };
+    rippleCanvas.addEventListener('transitionend', remove);
+    rippleCanvas.style.opacity = 0;
   }, RIPPLE_FADE_DELAY); // fade ripple gently, later
 
   setTimeout(() => {

--- a/stars.css
+++ b/stars.css
@@ -9,4 +9,6 @@ canvas#starfield {
   pointer-events: none;
   z-index: 0;
   background: transparent;
+  will-change: transform;
+  transform: translate3d(0, 0, 0);
 }

--- a/stars.js
+++ b/stars.js
@@ -4,6 +4,8 @@ const ctx = canvas.getContext('2d');
 let stars = [];
 let lastScrollY = 0;
 let shootingStar = null;
+let tiltX = 0, tiltY = 0;
+let targetTiltX = 0, targetTiltY = 0;
 
 function resizeCanvas() {
   canvas.width = window.innerWidth;
@@ -82,6 +84,9 @@ function drawStars(scrollY = 0) {
 function animate(time) {
   const targetScrollY = window.scrollY || window.pageYOffset;
   lastScrollY += (targetScrollY - lastScrollY) * 0.05; // smoothing
+  tiltX += (targetTiltX - tiltX) * 0.1;
+  tiltY += (targetTiltY - tiltY) * 0.1;
+  canvas.style.transform = `translate3d(${tiltX}px, ${tiltY}px, 0)`;
   drawStars(lastScrollY);
   drawShootingStar(time);
   requestAnimationFrame(animate);
@@ -89,13 +94,20 @@ function animate(time) {
 
 window.addEventListener('resize', () => {
   resizeCanvas();
-  createStars(isMobile() ? 100 : 150);
+  createStars(isMobile() ? 80 : 150);
 });
 
 function isMobile() {
   return /Mobi|Android/i.test(navigator.userAgent);
 }
 
+if (window.DeviceOrientationEvent) {
+  window.addEventListener('deviceorientation', e => {
+    targetTiltX = (e.gamma || 0) * 0.5;
+    targetTiltY = (e.beta || 0) * 0.5;
+  });
+}
+
 resizeCanvas();
-createStars(isMobile() ? 100 : 150);
+createStars(isMobile() ? 80 : 150);
 animate();


### PR DESCRIPTION
## Summary
- fully remove ripple canvas after intro
- let starfield canvas request GPU acceleration and respond to device orientation
- reduce star density on mobile

## Testing
- `node -v`

------
https://chatgpt.com/codex/tasks/task_e_683c9cd2b894832f88514b4e8099e86f