### PR TITLE
Fix leftover chalk ring

### DIFF
--- a/debug.js
+++ b/debug.js
@@ -93,6 +93,19 @@
         }
       }
     }, 500);
+
+    // After the intro sequence should be gone, check remaining children
+    setTimeout(() => {
+      const intro = document.getElementById('intro-sequence');
+      if (intro) {
+        console.log('[debug overlay] post-animation children:', Array.from(intro.children));
+        Array.from(intro.children).forEach(el => {
+          if (!el.classList.contains('ripple')) return;
+          el.remove();
+          console.log('[debug overlay] removed lingering element', el);
+        });
+      }
+    }, 8000);
   }
 
   if (document.readyState === 'loading') {

--- a/intro.js
+++ b/intro.js
@@ -133,6 +133,12 @@ window.addEventListener('DOMContentLoaded', () => {
     chalk.style.opacity = 1; // begin chalk fade in
   }, INTRO_REMOVE_DELAY); // remove overlay
 
+  // remove the chalk "e" element that lingers as a ring
+  setTimeout(() => {
+    const chalkE = document.getElementById('chalk-e');
+    if (chalkE) chalkE.remove();
+  }, INTRO_REMOVE_DELAY);
+
   // final safety removal for the ripple canvas if something prevented cleanup
   setTimeout(() => {
     if (rippleCanvas.parentNode) {


### PR DESCRIPTION
## Summary
- remove `chalk-e` element after intro sequence ends
- add debug overlay post-animation cleanup check for lingering elements

## Testing
- `node --check intro.js`
- `node --check debug.js`


------
https://chatgpt.com/codex/tasks/task_e_683e3c44513c832f89b22a6b330ad480