### PR TITLE
Add mystery element scan

### DIFF
--- a/debug.js
+++ b/debug.js
@@ -12,6 +12,7 @@
     style.textContent = `
       .debug-overlay { position:absolute; border:2px dashed red; box-sizing:border-box; pointer-events:none; z-index:9999; transition:opacity 0.5s; }
       .debug-overlay-unknown { border-color:magenta; }
+      .debug-overlay-mystery { border-color:cyan; }
       .debug-overlay-label { position:absolute; top:-1.2em; left:0; background:rgba(255,0,0,0.7); color:#fff; font-size:10px; padding:1px 4px; font-family:sans-serif; white-space:nowrap; }
     `;
     document.head.appendChild(style);
@@ -22,10 +23,12 @@
     overlays = [];
   }
 
-  function createOverlay(el, unknown) {
+  function createOverlay(el, type) {
     const rect = el.getBoundingClientRect();
     const overlay = document.createElement('div');
-    overlay.className = 'debug-overlay' + (unknown ? ' debug-overlay-unknown' : '');
+    overlay.className = 'debug-overlay' +
+      (type === 'unknown' ? ' debug-overlay-unknown' : '') +
+      (type === 'mystery' ? ' debug-overlay-mystery' : '');
     overlay.style.top = `${rect.top + window.scrollY}px`;
     overlay.style.left = `${rect.left + window.scrollX}px`;
     overlay.style.width = `${rect.width}px`;
@@ -33,8 +36,10 @@
 
     const label = document.createElement('div');
     label.className = 'debug-overlay-label';
-    if (unknown) {
+    if (type === 'unknown') {
       label.textContent = 'UNKNOWN';
+    } else if (type === 'mystery') {
+      label.textContent = 'MYSTERY';
     } else if (el.classList.contains('ripple')) {
       label.textContent = 'ripple';
     } else if (el.classList.contains('chalk')) {
@@ -70,8 +75,29 @@
       rect: e.getBoundingClientRect()
     })));
 
-    knownElements.forEach(el => createOverlay(el, false));
-    unknownElements.forEach(el => createOverlay(el, true));
+    knownElements.forEach(el => createOverlay(el));
+    unknownElements.forEach(el => createOverlay(el, 'unknown'));
+  }
+
+  function findMysteries() {
+    clearOverlays();
+    ensureStyle();
+    const all = Array.from(document.querySelectorAll('*'));
+    const mysteries = [];
+    all.forEach(el => {
+      const rect = el.getBoundingClientRect();
+      const cs = getComputedStyle(el);
+      if (rect.width <= 0 || rect.height <= 0) return;
+      if (parseFloat(cs.opacity) > 0 && cs.visibility !== 'hidden' && cs.display !== 'none') {
+        mysteries.push(el);
+      }
+    });
+    console.log('[debug overlay] MYSTERY elements:', mysteries.map(e => ({
+      tag: e.tagName.toLowerCase(),
+      classes: Array.from(e.classList).join(' '),
+      rect: e.getBoundingClientRect()
+    })));
+    mysteries.forEach(el => createOverlay(el, 'mystery'));
   }
 
   function startScanning() {
@@ -106,6 +132,9 @@
         });
       }
     }, 8000);
+
+    // One to two seconds after the intro fades, hunt for visible elements
+    setTimeout(findMysteries, 9500);
   }
 
   if (document.readyState === 'loading') {


### PR DESCRIPTION
## Summary
- extend debug overlays with a new `debug-overlay-mystery` style
- allow `createOverlay` to take a type parameter
- add a post-intro `findMysteries` sweep for lingering DOM elements

## Testing
- `pre-commit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_683e3e274838832f99f0d35e1ac02a2b