### PR TITLE
Add standalone visual element test pages

### DIFF
--- a/test-chalk.html
+++ b/test-chalk.html
@@ -1,0 +1,56 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Chalk Text Test</title>
+  <style>
+    html, body {
+      margin: 0;
+      height: 100%;
+      background: #000;
+      display: flex;
+      justify-content: center;
+      align-items: center;
+    }
+    .chalk-text {
+      font-family: "Comic Sans MS", cursive;
+      font-size: 2.5rem;
+      color: #fff;
+      text-shadow:
+        0 0 2px #fff,
+        0 0 6px rgba(255, 255, 255, 0.8),
+        1px 1px 2px rgba(0, 0, 0, 0.4);
+      filter: brightness(1.1) contrast(1.05);
+      animation: chalk-settle 3s ease forwards;
+      opacity: 0;
+    }
+    @keyframes chalk-settle {
+      from {
+        opacity: 0;
+        filter: blur(3px) brightness(1.3);
+      }
+      to {
+        opacity: 1;
+        filter: blur(0) brightness(1);
+      }
+    }
+  </style>
+</head>
+<body>
+  <div id="chalk" class="chalk-text">welcome.</div>
+  <script>
+    document.addEventListener('DOMContentLoaded', () => {
+      const el = document.getElementById('chalk');
+      el.addEventListener('animationend', () => {
+        console.log('chalk animation complete');
+      });
+      setTimeout(() => {
+        if (!document.querySelector('.chalk-text')) {
+          console.warn('chalk element missing');
+        }
+      }, 500);
+    });
+  </script>
+</body>
+</html>

--- a/test-enso.html
+++ b/test-enso.html
@@ -1,0 +1,71 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Enso Rotation Test</title>
+  <style>
+    html, body {
+      margin: 0;
+      height: 100%;
+      background: #000;
+      display: flex;
+      justify-content: center;
+      align-items: center;
+    }
+    canvas {
+      width: 70vmin;
+      height: 70vmin;
+    }
+  </style>
+</head>
+<body>
+  <canvas id="enso"></canvas>
+  <script>
+    const canvas = document.getElementById('enso');
+    const ctx = canvas.getContext('2d');
+    function resize() {
+      const size = Math.min(window.innerWidth, window.innerHeight) * 0.7;
+      canvas.width = canvas.height = size;
+    }
+    window.addEventListener('resize', resize);
+    resize();
+
+    const rotationSpeed = (2 * Math.PI) / 10000; // 10s period
+    function drawRing(time) {
+      const size = canvas.width;
+      const radius = size * 0.4;
+      const thickness = size * 0.08;
+      ctx.clearRect(0, 0, size, size);
+      ctx.save();
+      ctx.translate(size / 2, size / 2);
+      ctx.rotate(time * rotationSpeed);
+      const grad = ctx.createConicGradient(0, 0, 0);
+      grad.addColorStop(0, '#f00');
+      grad.addColorStop(1/6, '#ff0');
+      grad.addColorStop(2/6, '#0f0');
+      grad.addColorStop(3/6, '#0ff');
+      grad.addColorStop(4/6, '#00f');
+      grad.addColorStop(5/6, '#f0f');
+      grad.addColorStop(1, '#f00');
+      ctx.lineWidth = thickness;
+      ctx.strokeStyle = grad;
+      ctx.beginPath();
+      ctx.arc(0, 0, radius, 0, Math.PI * 2);
+      ctx.stroke();
+      ctx.restore();
+      requestAnimationFrame(drawRing);
+    }
+
+    requestAnimationFrame(drawRing);
+
+    setTimeout(() => {
+      if (!document.getElementById('enso')) {
+        console.error('enso canvas missing');
+      } else {
+        console.log('enso canvas rendering');
+      }
+    }, 500);
+  </script>
+</body>
+</html>

--- a/test-ripple.html
+++ b/test-ripple.html
@@ -1,0 +1,87 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Ripple Effect Test</title>
+  <style>
+    html, body {
+      margin: 0;
+      height: 100%;
+      background: #000;
+      overflow: hidden;
+    }
+    canvas {
+      width: 100vw;
+      height: 100vh;
+      display: block;
+    }
+  </style>
+</head>
+<body>
+  <canvas id="ripple" class="ripple"></canvas>
+  <script>
+    function startRippleAnimation(canvas) {
+      const ctx = canvas.getContext('2d');
+      let centerX = canvas.width / 2;
+      let centerY = canvas.height / 2;
+      let maxRadius = Math.sqrt(canvas.width ** 2 + canvas.height ** 2) / 2;
+      const ringDelays = [0, 800, 1600];
+      const duration = 4000;
+      let start;
+      let frameId;
+      function draw(t) {
+        if (!start) start = t;
+        const elapsed = t - start;
+        ctx.clearRect(0, 0, canvas.width, canvas.height);
+        ringDelays.forEach(delay => {
+          const progress = (elapsed - delay) / duration;
+          if (progress < 0 || progress > 1) return;
+          const radius = 2 + progress * maxRadius;
+          const alpha = 1 - Math.pow(progress, 2);
+          ctx.beginPath();
+          ctx.filter = `blur(${progress * 2}px)`;
+          ctx.strokeStyle = `rgba(255,255,255,${alpha})`;
+          ctx.lineWidth = 2;
+          ctx.arc(centerX, centerY, radius, 0, Math.PI * 2);
+          ctx.stroke();
+          ctx.filter = 'none';
+        });
+        if (elapsed < duration + ringDelays[ringDelays.length - 1]) {
+          frameId = requestAnimationFrame(draw);
+        }
+      }
+      function resize() {
+        canvas.width = window.innerWidth;
+        canvas.height = window.innerHeight;
+        centerX = canvas.width / 2;
+        centerY = canvas.height / 2;
+        maxRadius = Math.sqrt(canvas.width ** 2 + canvas.height ** 2) / 2;
+      }
+      window.addEventListener('resize', resize);
+      resize();
+      frameId = requestAnimationFrame(draw);
+      return () => {
+        cancelAnimationFrame(frameId);
+        window.removeEventListener('resize', resize);
+        ctx.clearRect(0, 0, canvas.width, canvas.height);
+      };
+    }
+
+    document.addEventListener('DOMContentLoaded', () => {
+      const canvas = document.getElementById('ripple');
+      const cancel = startRippleAnimation(canvas);
+      setTimeout(() => {
+        cancel();
+        canvas.remove();
+        const remain = document.querySelector('.ripple');
+        if (remain) {
+          console.warn('ripple element failed to remove');
+        } else {
+          console.log('ripple element removed');
+        }
+      }, 6500);
+    });
+  </script>
+</body>
+</html>

--- a/test-scroll.html
+++ b/test-scroll.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Scroll Event Test</title>
+  <style>
+    html, body {
+      margin: 0;
+      height: 100%;
+      font-family: sans-serif;
+    }
+    header {
+      position: fixed;
+      top: 0;
+      left: 0;
+      right: 0;
+      background: #222;
+      color: #fff;
+      padding: 1rem;
+      text-align: center;
+      transition: opacity 0.5s ease;
+    }
+    main {
+      padding-top: 80px;
+      min-height: 200vh;
+      background: linear-gradient(#000, #333);
+      color: #fff;
+    }
+  </style>
+</head>
+<body>
+  <header id="head">scroll down to test events</header>
+  <main></main>
+  <script>
+    const header = document.getElementById('head');
+    window.addEventListener('scroll', () => {
+      const y = window.scrollY || window.pageYOffset;
+      console.log('scrollY', y);
+      header.style.opacity = y > 50 ? '0.4' : '1';
+    });
+
+    setTimeout(() => {
+      if (!header) {
+        console.warn('header element missing');
+      } else {
+        console.log('scroll logic ready');
+      }
+    }, 500);
+  </script>
+</body>
+</html>

--- a/test-stars.html
+++ b/test-stars.html
@@ -1,0 +1,82 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Starfield Test</title>
+  <style>
+    html, body {
+      margin: 0;
+      height: 100%;
+      overflow: hidden;
+      background: #000;
+    }
+    canvas {
+      width: 100vw;
+      height: 100vh;
+      display: block;
+    }
+  </style>
+</head>
+<body>
+  <canvas id="starfield"></canvas>
+  <script>
+    const canvas = document.getElementById('starfield');
+    const ctx = canvas.getContext('2d');
+    let stars = [];
+    let lastScrollY = 0;
+
+    function resize() {
+      canvas.width = window.innerWidth;
+      canvas.height = window.innerHeight;
+    }
+
+    function createStars(count) {
+      stars = [];
+      for (let i = 0; i < count; i++) {
+        stars.push({
+          x: Math.random() * canvas.width,
+          y: Math.random() * canvas.height,
+          radius: Math.random() * 1.2 + 0.2,
+          alpha: Math.random() * 0.5 + 0.3,
+          delta: Math.random() * 0.005,
+          depth: Math.random() * 0.5 + 0.5
+        });
+      }
+    }
+
+    function drawStars(scrollY = 0) {
+      ctx.clearRect(0, 0, canvas.width, canvas.height);
+      for (const star of stars) {
+        star.alpha += star.delta;
+        if (star.alpha <= 0.3 || star.alpha >= 0.8) star.delta = -star.delta;
+        const offsetY = scrollY * star.depth * 0.05;
+        ctx.beginPath();
+        ctx.arc(star.x, star.y + offsetY, star.radius, 0, Math.PI * 2);
+        ctx.fillStyle = `rgba(255,255,255,${star.alpha})`;
+        ctx.fill();
+      }
+    }
+
+    function animate(time) {
+      const targetScrollY = window.scrollY || window.pageYOffset;
+      lastScrollY += (targetScrollY - lastScrollY) * 0.05;
+      drawStars(lastScrollY);
+      requestAnimationFrame(animate);
+    }
+
+    window.addEventListener('resize', () => { resize(); createStars(150); });
+    resize();
+    createStars(150);
+    animate();
+
+    setTimeout(() => {
+      if (!document.getElementById('starfield')) {
+        console.warn('starfield canvas missing');
+      } else {
+        console.log('starfield running');
+      }
+    }, 500);
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add `test-ripple.html` to isolate ripple effect
- add `test-enso.html` for rotating enso
- add `test-stars.html` to view starfield/parallax
- add `test-chalk.html` for chalk text fade-in
- add `test-scroll.html` demonstrating scroll events

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_683e58442f08832fb57e9da9c6983cf3