### PR TITLE
Add cleanup script

### DIFF
--- a/cleanup.js
+++ b/cleanup.js
@@ -1,0 +1,38 @@
+const fs = require('fs');
+const path = require('path');
+
+// Define sacred files to keep
+const sacredFiles = new Set([
+  'index.html',
+  'enso.html',
+  'stars.js',
+  'orbits.js',
+  'light.js',
+  'init.js',
+  'doxa.js',
+  'enso.js',
+  'offering.js',
+  'glyphs.js',
+  'lexicon.js',
+  'order.js',
+  'resonance.js',
+  'invitation.js',
+  'aether.js'
+]);
+
+// Create backup directory if it doesn't exist
+const backupDir = path.join(__dirname, 'backup');
+if (!fs.existsSync(backupDir)) {
+  fs.mkdirSync(backupDir);
+}
+
+// Move everything not in the sacred list to backup
+fs.readdirSync(__dirname).forEach(file => {
+  if (!sacredFiles.has(file) && file !== 'backup') {
+    const source = path.join(__dirname, file);
+    const dest = path.join(backupDir, file);
+    fs.renameSync(source, dest);
+  }
+});
+
+console.log('Cleanup complete. Only sacred files remain.');


### PR DESCRIPTION
## Summary
- introduce `cleanup.js` script to move non-specified files into a `backup` folder

## Testing
- `node -v`


------
https://chatgpt.com/codex/tasks/task_e_683fbaeacd20832faf7686dfbf4e0693