### PR TITLE
Consolidate feather animation logic

### DIFF
--- a/feather-test.html
+++ b/feather-test.html
@@ -41,53 +41,6 @@
       height: 100%;
     }
 
-    .feather {
-      width: 100%;
-      height: 100%;
-      opacity: 0;
-      transform: translate3d(0, -3em, 0) rotateZ(0deg) rotateY(0deg);
-      will-change: transform, opacity;
-      transform-origin: center;
-    }
-
-    .feather-animate {
-      opacity: 1;
-      animation: featherFall 6s cubic-bezier(0.25, 1, 0.5, 1) forwards;
-    }
-
-    @keyframes featherFall {
-      0% {
-        transform: translate3d(0, -3em, 0) rotateZ(0deg) rotateY(0deg);
-      }
-
-      10% {
-        transform: translate3d(0, -2.7em, 0) rotateZ(2deg) rotateY(-1deg);
-      }
-
-      20% {
-        transform: translate3d(0, -2em, 0) rotateZ(3deg) rotateY(-2deg);
-      }
-
-      45% {
-        transform: translate3d(0, -1em, 0) rotateZ(-2deg) rotateY(3deg);
-      }
-
-      70% {
-        transform: translate3d(0, -0.2em, 0) rotateZ(1deg) rotateY(-1deg);
-      }
-
-      100% {
-        transform: translate3d(0, 0, 0) rotateZ(0deg) rotateY(0deg);
-      }
-    }
-
-    svg path {
-      fill: none;
-      stroke: white;
-      stroke-width: 1.5;
-      stroke-linecap: round;
-      stroke-linejoin: round;
-    }
   </style>
 </head>
 <body>

--- a/feather.js
+++ b/feather.js
@@ -2,6 +2,11 @@
 // renders a hand-traced feather glyph with scroll-compatible styling
 
 function renderFeather(container) {
+  if (container.dataset.featherLoaded) {
+    return;
+  }
+  container.dataset.featherLoaded = 'true';
+
   // Add the refined feather animation styles
   const style = document.createElement('style');
   style.textContent = `
@@ -75,8 +80,14 @@ function renderFeather(container) {
         svg.setAttribute('height', '1em');
         svg.classList.add('feather');
         setTimeout(() => {
-          svg.classList.add('feather-animate');
+          if (!svg.classList.contains('feather-animate')) {
+            svg.classList.add('feather-animate');
+          }
         }, 100);
+
+        svg.addEventListener('animationend', () => {
+          console.log('Feather animation complete');
+        }, { once: true });
 
         // Apply the refined styling
         svg.querySelectorAll('path, line').forEach(el => {


### PR DESCRIPTION
## Summary
- clean up `feather-test.html` styles so layout only comes from the HTML file
- move all animation styling to `feather.js`
- guard against duplicate animation runs
- log when the feather animation finishes

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6854d49402d8832fa9ff673a6ff82f53