### PR TITLE
Fix feather loading flag set on fetch failure

### DIFF
--- a/feather.js
+++ b/feather.js
@@ -2,6 +2,9 @@
 // renders a hand-traced feather glyph with scroll-compatible styling
 
 function renderFeather(container) {
+  if (container.dataset.featherLoaded) {
+    return;
+  }
   // Add the refined feather animation styles
   const style = document.createElement('style');
   style.textContent = `
@@ -87,6 +90,7 @@ function renderFeather(container) {
           el.setAttribute('stroke-linejoin', 'round');
         });
       }
+      container.dataset.featherLoaded = 'true';
     })
     .catch(error => {
       console.error('Failed to load feather.svg:', error);


### PR DESCRIPTION
## Summary
- prevent multiple render calls in `renderFeather`
- only set `dataset.featherLoaded` after SVG fetch succeeds

## Testing
- `node --check feather.js`


------
https://chatgpt.com/codex/tasks/task_e_68555aa04964832fbbe1cc477fbd41d6